### PR TITLE
Removed Linux-ism from rdrview.filter.dpi shell-script

### DIFF
--- a/rdrview.filter.dpi
+++ b/rdrview.filter.dpi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Rodrigo Arias Mallo
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
This small commit removes "Linux-ism" from `rdrview.filter.dpi` so this plugin can be used with e.g. FreeBSD.

Since `bash` lies in the `/bin/` catalog in Linux, but not in another OSes (e.g. `/usr/local/bin/bash` for FreeBSD, `/usr/pkg/bin/bash` for NetBSD), the most reliable way to specify she-bang will be:

```shell
#!/usr/bin/env bash
```

The `env` will execute bash from the right path, using the `$PATH` value.